### PR TITLE
Initial description of a declarative custom section

### DIFF
--- a/proposals/custom-descriptors/Overview.md
+++ b/proposals/custom-descriptors/Overview.md
@@ -607,7 +607,7 @@ A declared value can optionally specify the index of a previous value
 to serve as the parent in the configured prototype chain.
 Imported values are assumed to already have their prototype chain configured.
 
-Each configured descriptor is has a vector of export names.
+Each configured descriptor has a vector of export names.
 These are the names from which the Wasm module will import the descriptor values.
 
 Whether imported or declared,

--- a/proposals/custom-descriptors/Overview.md
+++ b/proposals/custom-descriptors/Overview.md
@@ -656,6 +656,10 @@ giving the exports from the descriptors sections precedence.
 
 After core instantiation,
 the methods are populated based on the core exports.
+Since this does not happen until after core instantiation,
+when the exports have been made available,
+imports called by the start function will be able to observe
+the unpopulated prototypes that do not yet have the method properties.
 
 If there is a decoding error in a descriptors section
 or if at any point a required import or export is missing,

--- a/proposals/custom-descriptors/Overview.md
+++ b/proposals/custom-descriptors/Overview.md
@@ -676,6 +676,7 @@ or if at any point a required import or export is missing,
 an error will be thrown.
 
 > TODO: Describe the effect of the descriptors section on Module.imports and Module.exports.
+> TODO: Make sure the prototypes can be read from the exports for further manual configuration.
 
 ## Type Section Field Deduplication
 

--- a/proposals/custom-descriptors/Overview.md
+++ b/proposals/custom-descriptors/Overview.md
@@ -676,7 +676,12 @@ or if at any point a required import or export is missing,
 an error will be thrown.
 
 > TODO: Describe the effect of the descriptors section on Module.imports and Module.exports.
+
 > TODO: Make sure the prototypes can be read from the exports for further manual configuration.
+
+> TODO: Consider supporting declarative static methods attached to constructors instead of methods.
+
+> TODO: Declarative support for installing Symbol.hasInstance methods to support instanceof.
 
 ## Type Section Field Deduplication
 

--- a/proposals/custom-descriptors/Overview.md
+++ b/proposals/custom-descriptors/Overview.md
@@ -543,7 +543,11 @@ console.log(counter.get()); // 1
 ## Declarative Prototype Initialization
 
 We expect toolchains to need to configure thousands of JS prototypes and tens of thousands of methods,
-so to reduce startup latency we want a declarative method of constructing, importing,
+so we expect there to be startup latency problems
+if all the configuration is done directly via the raw `DescriptorOptions` API
+and JS glue code as shown above.
+
+The proposed solution is to provide a declarative method of constructing, importing,
 and populating the `DescriptorOptions` objects.
 
 The declarative API must support these features:
@@ -553,7 +557,12 @@ The declarative API must support these features:
  - Creating prototype chains
  - Synthesizing and attaching methods (including getters and setters) to prototypes
 
-We define a new custom section to be specified as part of the JS embedding.
+Furthermore, the design goals are to be:
+
+ - Polyfillable by generated JS glue using the underlying `DescriptorOptions` JS API,
+   i.e. to not introduce any new expressivity.
+
+We define such an API in the form of a new custom section to be specified as part of the JS embedding.
 This custom section will be used in the constructor of `WebAssembly.Instance`
 to populate the imports with additional `DescriptorOptions` before core instantiation
 and to populate the prototypes using exported functions after core instantiation.

--- a/proposals/custom-descriptors/Overview.md
+++ b/proposals/custom-descriptors/Overview.md
@@ -567,6 +567,8 @@ This custom section will be used in the constructor of `WebAssembly.Instance`
 to populate the imports with additional `DescriptorOptions` before core instantiation
 and to populate the prototypes using exported functions after core instantiation.
 
+### Custom Section
+
 ```
 descindex       ::= u32
 
@@ -650,6 +652,8 @@ Instead, they are added to the `exports` object.
 The configured prototype is added as the `prototype` property of the generated function
 and the generated function is added as the `constructor` property of the configured prototype.
 
+### Instantiation
+
 When constructing a WebAssembly instance,
 the descriptors sections are first processed
 to create any new declared `DescriptorOptions`.
@@ -670,6 +674,8 @@ the unpopulated prototypes that do not yet have the method properties.
 If there is a decoding error in a descriptors section
 or if at any point a required import or export is missing,
 an error will be thrown.
+
+> TODO: Describe the effect of the descriptors section on Module.imports and Module.exports.
 
 ## Type Section Field Deduplication
 

--- a/proposals/custom-descriptors/Overview.md
+++ b/proposals/custom-descriptors/Overview.md
@@ -593,10 +593,9 @@ methodconfig    ::= kind:methodkind
                     methodname:name
                     exportname:name
 
-methodkind      ::= 0x00 => static
-                  | 0x01 => method
-                  | 0x02 => getter
-                  | 0x03 => setter
+methodkind      ::= 0x00 => method
+                  | 0x01 => getter
+                  | 0x02 => setter
 ```
 
 The descriptors custom section starts with `modulename`,
@@ -623,19 +622,13 @@ Whether imported or declared,
 each `descriptorentry` contains a vector of `methodconfig`
 describing the methods that should be attached to the prototype
 after instantiation.
-Each configured method can be either a static method,
+Each configured method can be either a
 normal method, a getter, or a setter.
 Methods also have two associated names: the first their property name
 in the configured prototype and the second
 the name of the exported function they wrap.
 
-Static methods do not pass their receiver as an argument to the exported function:
-
-```js
-function methodname() { return exports[exportname](...arguments); }
-```
-
-All other methods pass the receiver as the first argument:
+All methods pass the receiver as the first argument:
 
 ```js
 function methodname() { return exports[exportname](this, ...arguments); }

--- a/proposals/custom-descriptors/Overview.md
+++ b/proposals/custom-descriptors/Overview.md
@@ -596,6 +596,7 @@ methodconfig    ::= kind:methodkind
 methodkind      ::= 0x00 => method
                   | 0x01 => getter
                   | 0x02 => setter
+                  | 0x03 => constructor
 ```
 
 The descriptors custom section starts with `modulename`,
@@ -623,7 +624,7 @@ each `descriptorentry` contains a vector of `methodconfig`
 describing the methods that should be attached to the prototype
 after instantiation.
 Each configured method can be either a
-normal method, a getter, or a setter.
+normal method, a getter, a setter, or a constructor.
 Methods also have two associated names: the first their property name
 in the configured prototype and the second
 the name of the exported function they wrap.
@@ -636,6 +637,18 @@ function methodname() { return exports[exportname](this, ...arguments); }
 
 Getters and setters are additionally configured as getters and setters
 when they are attached to the prototype.
+
+Constructors are a little different.
+They do not pass the receiver as a parameter to the exported function:
+
+```js
+function methodname() { return exports[exportname](...arguments); }
+```
+
+Furthermore, they are not installed on the configured prototype.
+Instead, they are added to the `exports` object.
+The configured prototype is added as the `prototype` property of the generated function
+and the generated function is added as the `constructor` property of the configured prototype.
 
 When constructing a WebAssembly instance,
 the descriptors sections are first processed

--- a/proposals/custom-descriptors/Overview.md
+++ b/proposals/custom-descriptors/Overview.md
@@ -658,7 +658,7 @@ argument passed to instantiation using the module names
 given at the beginning of the sections.
 
 The imports for core Wasm instantiation are then determined,
-giving the exports from the descriptors sections precedence.
+giving precedence to the exports from the descriptors sections.
 
 After core instantiation,
 the methods are populated based on the core exports.


### PR DESCRIPTION
Describe a custom section used to declaratively configure
`DescriptorOptions` objects to be passed as imports to core
instantiation and populated using exported functions after core
instantiation.
