### PR TITLE
[interpreter] Custom descriptor syntax

### DIFF
--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -185,10 +185,18 @@ struct
     | DefArrayT at -> s7 (-0x22); array_type at
     | DefFuncT ft -> s7 (-0x20); func_type ft
 
+  let described_type = function
+    | DescriptorT (ht, st) -> s7 (-0x33); var_heap_type ht; str_type st
+    | NoDescriptorT st -> str_type st
+
+  let described_type = function
+    | DescribesT (ht, dt) -> s7 (-0x34); var_heap_type ht; described_type dt
+    | NoDescribesT dt -> described_type dt
+
   let sub_type = function
-    | SubT (Final, [], st) -> str_type st
-    | SubT (Final, hts, st) -> s7 (-0x31); vec var_heap_type hts; str_type st
-    | SubT (NoFinal, hts, st) -> s7 (-0x30); vec var_heap_type hts; str_type st
+    | SubT (Final, [], dt) -> described_type dt
+    | SubT (Final, hts, dt) -> s7 (-0x31); vec var_heap_type hts; described_type dt
+    | SubT (NoFinal, hts, dt) -> s7 (-0x30); vec var_heap_type hts; described_type dt
 
   let rec_type = function
     | RecT [st] -> sub_type st

--- a/interpreter/custom/handler_name.ml
+++ b/interpreter/custom/handler_name.ml
@@ -402,7 +402,14 @@ let check_error at msg = raise (Custom.Invalid (at, msg))
 let check (m : module_) (fmt : format) =
   let subtypes =
     List.concat (List.map (fun {it = RecT ss; _} -> ss) m.it.types) in
-  let comptypes = List.map (fun (SubT (_, _, ct)) -> ct) subtypes in
+  let comptypes = List.map (fun (SubT (_, _, dt)) ->
+                      let dt = match dt with
+                        | DescribesT (_, dt) -> dt
+                        | NoDescribesT dt -> dt in
+                      let ct = match dt with
+                        | DescriptorT (_, ct) -> ct
+                        | NoDescriptorT ct -> ct in
+                      ct) subtypes in
   IdxMap.iter (fun x name ->
     if I32.ge_u x (Lib.List32.length m.it.funcs) then
       check_error name.at ("custom @name: invalid function index " ^

--- a/interpreter/host/spectest.ml
+++ b/interpreter/host/spectest.ml
@@ -32,7 +32,7 @@ let memory =
   ExternMemory (Memory.alloc mt)
 
 let func f ft =
-  let dt = DefT (RecT [SubT (Final, [], DefFuncT ft)], 0l) in
+  let dt = DefT (RecT [SubT (Final, [], NoDescribesT (NoDescriptorT (DefFuncT ft)))], 0l) in
   ExternFunc (Func.alloc_host dt (f ft))
 
 let print_value v =

--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -324,7 +324,7 @@ let value v =
   | Ref _ -> assert false
 
 let invoke ft vs at =
-  let dt = RecT [SubT (Final, [], DefFuncT ft)] in
+  let dt = RecT [SubT (Final, [], NoDescribesT (NoDescriptorT (DefFuncT ft)))] in
   [dt @@ at], FuncImport (subject_type_idx @@ at) @@ at,
   List.concat (List.map value vs) @ [Call (subject_idx @@ at) @@ at]
 
@@ -493,7 +493,7 @@ let i32 = NumT I32T
 let anyref = RefT (Null, AnyHT)
 let eqref = RefT (Null, EqHT)
 let func_rec_type ts1 ts2 at =
-  RecT [SubT (Final, [], DefFuncT (FuncT (ts1, ts2)))] @@ at
+  RecT [SubT (Final, [], NoDescribesT (NoDescriptorT (DefFuncT (FuncT (ts1, ts2)))))] @@ at
 
 let wrap item_name wrap_action wrap_assertion at =
   let itypes, idesc, action = wrap_action at in

--- a/interpreter/syntax/free.ml
+++ b/interpreter/syntax/free.ml
@@ -111,8 +111,16 @@ let str_type = function
   | DefArrayT at -> array_type at
   | DefFuncT ft -> func_type ft
 
+let described_type = function
+  | DescriptorT (ht, st) -> heap_type ht ++ str_type st
+  | NoDescriptorT st -> str_type st
+
+let describing_type = function
+  | DescribesT (ht, dt) -> heap_type ht ++ described_type dt
+  | NoDescribesT dt -> described_type dt
+
 let sub_type = function
-  | SubT (_fin, hts, st) -> list heap_type hts ++ str_type st
+  | SubT (_fin, hts, dt) -> list heap_type hts ++ describing_type dt
 
 let rec_type = function
   | RecT sts -> list sub_type sts

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -106,11 +106,21 @@ let str_type st =
   | DefArrayT at -> array_type at
   | DefFuncT ft -> func_type ft
 
+let described_type dt =
+  match dt with
+  | DescriptorT (ht, st) -> Node ("descriptor", [atom heap_type ht; str_type st])
+  | NoDescriptorT st -> str_type st
+
+let describing_type dt =
+  match dt with
+  | DescribesT (ht, dt) -> Node ("describes", [atom heap_type ht; described_type dt])
+  | NoDescribesT dt -> described_type dt
+
 let sub_type = function
-  | SubT (Final, [], st) -> str_type st
-  | SubT (fin, xs, st) ->
+  | SubT (Final, [], dt) -> describing_type dt
+  | SubT (fin, xs, dt) ->
     Node (String.concat " "
-      (("sub" ^ final fin ):: List.map heap_type xs), [str_type st])
+      (("sub" ^ final fin ):: List.map heap_type xs), [describing_type dt])
 
 let rec_type i j st =
   Node ("type $" ^ nat (i + j), [sub_type st])

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -89,7 +89,7 @@ let character =
     [^'"''\\''\x00'-'\x1f''\x7f'-'\xff']
   | utf8enc
   | '\\'escape
-  | '\\'hexdigit hexdigit 
+  | '\\'hexdigit hexdigit
   | "\\u{" hexnum '}'
 
 let nat = num | "0x" hexnum
@@ -184,6 +184,8 @@ rule token = parse
       | "struct" -> STRUCT
       | "field" -> FIELD
       | "mut" -> MUT
+      | "descriptor" -> DESCRIPTOR
+      | "describes" -> DESCRIBES
       | "sub" -> SUB
       | "final" -> FINAL
       | "rec" -> REC

--- a/test/core/descriptors.wast
+++ b/test/core/descriptors.wast
@@ -1,0 +1,31 @@
+;; Test custom descriptors
+
+(module
+  (rec
+    (type (descriptor 1 (struct)))
+    (type (describes 0 (struct)))
+  )
+)
+
+(module
+  (rec
+    (type $super (sub (descriptor $super-desc (struct))))
+    (type $super-desc (sub (describes $super (struct))))
+  )
+  (rec
+    (type $sub (sub $super (descriptor $sub-desc (struct))))
+    (type $sub-desc (sub $super-desc (describes $sub (struct))))
+  )
+)
+
+(module
+  (type $super (sub (struct)))
+  (rec
+    (type $other (sub (descriptor $super-desc (struct))))
+    (type $super-desc (sub (describes $other (struct))))
+  )
+  (rec
+    (type $sub (sub $super (descriptor $sub-desc (struct))))
+    (type $sub-desc (sub $super-desc (describes $sub (struct))))
+  )
+)


### PR DESCRIPTION
Add descriptor and describes clauses to the syntax of types. Update the
various operations on types accordingly, including text and binary
parsing and writing.
