### PR TITLE
[interpreter] Descriptor type validation

### DIFF
--- a/interpreter/valid/match.ml
+++ b/interpreter/valid/match.ml
@@ -160,6 +160,19 @@ and match_deftype c dt1 dt2 =
     match_heaptype c (UseHT (Inexact, ut1)) (UseHT (Inexact, (Def dt2)))
   ) uts1
 
+let match_typeuse c ut1 ut2 (rt1 : rectype) (rt2 : rectype) =
+  let dt1 = match ut1 with
+    | Idx x -> lookup c x
+    | Rec i -> DefT (rt1, i)
+    | Def dt -> dt
+  in
+  let dt2 = match ut2 with
+    | Idx x -> lookup c x
+    | Rec i -> DefT (rt2, i)
+    | Def dt -> dt
+  in
+  match_deftype c dt1 dt2
+
 let match_tagtype c (TagT ut1) (TagT ut2) =
   match ut1, ut2 with
   | Def dt1, Def dt2 -> match_deftype c dt1 dt2 && match_deftype c dt2 dt1

--- a/interpreter/valid/match.mli
+++ b/interpreter/valid/match.mli
@@ -28,6 +28,7 @@ val match_storagetype : context -> storagetype -> storagetype -> bool
 
 val match_comptype : context -> comptype -> comptype -> bool
 val match_deftype : context -> deftype -> deftype -> bool
+val match_typeuse : context -> typeuse -> typeuse -> rectype -> rectype -> bool
 
 val match_tabletype : context -> tabletype -> tabletype -> bool
 val match_memorytype : context -> memorytype -> memorytype -> bool

--- a/test/core/custom-descriptors/descriptors.wast
+++ b/test/core/custom-descriptors/descriptors.wast
@@ -5,13 +5,6 @@
     (type (descriptor 1) (struct))
     (type (describes 0) (struct))
   )
-)
-
-(module
-  (rec
-    (type (descriptor 1) (struct))
-    (type (describes 0) (struct))
-  )
   (rec
     (type $a (descriptor $b) (struct))
     (type $b (describes $a) (struct))
@@ -71,4 +64,420 @@
     ")"
   )
   "unexpected token"
+)
+
+;; Type validation
+
+(assert_invalid
+  (module
+    (type (descriptor 1) (struct))
+  )
+  "descriptor type is outside rec group"
+)
+
+(assert_invalid
+  (module
+    (type (describes 1) (struct))
+  )
+  "described type is outside rec group"
+)
+
+(assert_invalid
+  (module
+    (type (descriptor 1) (struct))
+    (type (struct))
+  )
+  "descriptor type is outside rec group"
+)
+
+(assert_invalid
+  (module
+    (type (describes 1) (struct))
+    (type (struct))
+  )
+  "described type is outside rec group"
+)
+
+(assert_invalid
+  (module
+    (type (struct))
+    (type (descriptor 0) (struct))
+  )
+  "descriptor type is outside rec group"
+)
+
+(assert_invalid
+  (module
+    (type (struct))
+    (type (describes 0) (struct))
+  )
+  "described type is outside rec group"
+)
+
+(assert_invalid
+  (module
+    (rec
+      (type (descriptor 1) (struct))
+      (type (struct))
+    )
+  )
+  "type is not described by its descriptor"
+)
+
+(assert_invalid
+  (module
+    (rec
+      (type (struct))
+      (type (describes 0) (struct))
+    )
+  )
+  "described type is not described by descriptor"
+)
+
+(assert_invalid
+  (module
+    (rec
+      (type (describes 1) (struct))
+      (type (descriptor 0) (struct))
+    )
+  )
+  "forward use of described type"
+)
+
+(assert_invalid
+  (module
+    (type (describes 0) (descriptor 0) (struct))
+  )
+  "forward use of described type"
+)
+
+(assert_invalid
+  (module
+    (type (descriptor 1) (struct))
+    (type (describes 0) (struct))
+  )
+  "descriptor type is outside rec group"
+)
+
+(assert_invalid
+  (module
+    (rec
+      (type (descriptor 1) (func))
+      (type (describes 0) (struct))
+    )
+  )
+  "descriptor type must be a struct"
+)
+
+(assert_invalid
+  (module
+    (rec
+      (type (descriptor 1) (struct))
+      (type (describes 0) (func))
+    )
+  )
+  "described type must be a struct"
+)
+
+(assert_invalid
+  (module
+    (rec
+      (type (descriptor 1) (func))
+      (type (describes 0) (func))
+    )
+  )
+  "descriptor type must be a struct"
+)
+
+(assert_invalid
+  (module
+    (rec
+      (type (descriptor 1) (array i8))
+      (type (describes 0) (struct))
+    )
+  )
+  "descriptor type must be a struct"
+)
+
+(assert_invalid
+  (module
+    (rec
+      (type (descriptor 1) (struct))
+      (type (describes 0) (array i8))
+    )
+  )
+  "described type must be a struct"
+)
+
+(assert_invalid
+  (module
+    (rec
+      (type (descriptor 1) (array i8))
+      (type (describes 0) (array i8))
+    )
+  )
+  "descriptor type must be a struct"
+)
+
+;; Subtyping
+
+(module
+  (rec
+    (type $A (sub (descriptor $A.desc) (struct)))
+    (type $A.desc (sub (describes $A) (struct)))
+    (type $B (sub $A (descriptor $B.desc) (struct)))
+    (type $B.desc (sub $A.desc (describes $B) (struct)))
+  )
+)
+
+(module
+  (rec
+    (type $A (sub (descriptor $A.desc) (struct)))
+    (type $B (sub $A (descriptor $B.desc) (struct)))
+    (type $A.desc (sub (describes $A) (struct)))
+    (type $B.desc (sub $A.desc (describes $B) (struct)))
+  )
+)
+
+(module
+  (rec
+    (type $A (sub (descriptor $A.desc) (struct)))
+    (type $A.desc (sub (describes $A) (struct)))
+  )
+  (rec
+    (type $B (sub $A (descriptor $B.desc) (struct)))
+    (type $B.desc (sub $A.desc (describes $B) (struct)))
+  )
+)
+
+;; If a subtype has a descriptor, its supertype does not need to have a
+;; descriptor.
+(module
+  (rec
+    (type $A (sub (struct)))
+    (type $B (sub $A (descriptor $B.desc) (struct)))
+    (type $B.desc (sub (describes $B) (struct)))
+  )
+)
+(module
+  (rec
+    (type $A (sub (struct)))
+  )
+  (rec
+    (type $B (sub $A (descriptor $B.desc) (struct)))
+    (type $B.desc (sub (describes $B) (struct)))
+  )
+)
+
+;; If a supertype has a descriptor, its subtype must also have a descriptor.
+(assert_invalid
+  (module
+    (rec
+      (type $A (sub (descriptor $A.desc) (struct)))
+      (type $A.desc (sub (describes $A) (struct)))
+      (type $B (sub $A (struct)))
+    )
+  )
+  "sub type 2 does not match super type 0"
+)
+(assert_invalid
+  (module
+    (rec
+      (type $A (sub (descriptor $A.desc) (struct)))
+      (type $A.desc (sub (describes $A) (struct)))
+    )
+    (rec
+      (type $B (sub $A (struct)))
+    )
+  )
+  "sub type 2 does not match super type 0"
+)
+
+
+;; If a subtype has a described type, its supertype must also have a described
+;; type.
+(assert_invalid
+  (module
+    (rec
+      (type $A.desc (sub (struct)))
+      (type $B (sub (descriptor $B.desc) (struct)))
+      (type $B.desc (sub $A.desc (describes $B) (struct)))
+    )
+  )
+  "sub type 2 does not match super type 0"
+)
+(assert_invalid
+  (module
+    (rec
+      (type $A.desc (sub (struct)))
+    )
+    (rec
+      (type $B (sub (descriptor $B.desc) (struct)))
+      (type $B.desc (sub $A.desc (describes $B) (struct)))
+    )
+  )
+  "sub type 2 does not match super type 0"
+)
+
+;; If a supertype has a described type, its subtype must also have a described
+;; type.
+(assert_invalid
+  (module
+    (rec
+      (type $A (sub (descriptor $A.desc) (struct)))
+      (type $A.desc (sub (describes $A) (struct)))
+      (type $B.desc (sub $A.desc (struct)))
+    )
+  )
+  "sub type 2 does not match super type 1"
+)
+(assert_invalid
+  (module
+    (rec
+      (type $A (sub (descriptor $A.desc) (struct)))
+      (type $A.desc (sub (describes $A) (struct)))
+    )
+    (rec
+      (type $B.desc (sub $A.desc (struct)))
+    )
+  )
+  "sub type 2 does not match super type 1"
+)
+
+;; The subtype's descriptor must be a subtype of the supertype's descriptor.
+(assert_invalid
+  (module
+    (rec
+      (type $A (sub (descriptor $A.desc) (struct)))
+      (type $A.desc (sub (describes $A) (struct)))
+      (type $B (sub $A (descriptor $B.desc) (struct)))
+      (type $B.desc (sub (describes $B) (struct))) ;; Not a subtype of A.desc.
+    )
+  )
+  "descriptor type 3 does not match"
+)
+(assert_invalid
+  (module
+    (rec
+      (type $A (sub (descriptor $A.desc) (struct)))
+      (type $A.desc (sub (describes $A) (struct)))
+    )
+    (rec
+      (type $B (sub $A (descriptor $B.desc) (struct)))
+      (type $B.desc (sub (describes $B) (struct))) ;; Not a subtype of A.desc.
+    )
+  )
+  "descriptor type 3 does not match"
+)
+
+
+;; The supertype's described type must be a supertype of the subtype's described
+;; type.
+(assert_invalid
+  (module
+    (rec
+      (type $A (sub (descriptor $A.desc) (struct)))
+      (type $A.desc (sub (describes $A) (struct)))
+      (type $B (sub (descriptor $B.desc) (struct))) ;; Not a subtype of A.
+      (type $B.desc (sub $A.desc (describes $B) (struct)))
+    )
+  )
+  "described type 2 does not match"
+)
+(assert_invalid
+  (module
+    (rec
+      (type $A (sub (descriptor $A.desc) (struct)))
+      (type $A.desc (sub (describes $A) (struct)))
+    )
+    (rec
+      (type $B (sub (descriptor $B.desc) (struct))) ;; Not a subtype of A.
+      (type $B.desc (sub $A.desc (describes $B) (struct)))
+    )
+  )
+  "described type 2 does not match"
+)
+
+;; The supertype of a descriptor must describe the supertype of the descriptor's
+;; described type.
+(assert_invalid
+  (module
+    (rec
+      (type $A (sub (struct))) ;; Not described by A.desc.
+      (type $A.desc (sub (struct))) ;; Does not describe A.
+      (type $B (sub $A (descriptor $B.desc) (struct)))
+      (type $B.desc (sub $A.desc (describes $B) (struct)))
+    )
+  )
+  "sub type 3 does not match super type 1"
+)
+(assert_invalid
+  (module
+    (rec
+      (type $A (sub (struct))) ;; Not described by A.desc.
+      (type $A.desc (sub (struct))) ;; Does not describe A.
+    )
+    (rec
+      (type $B (sub $A (descriptor $B.desc) (struct)))
+      (type $B.desc (sub $A.desc (describes $B) (struct)))
+    )
+  )
+  "sub type 3 does not match super type 1"
+)
+(assert_invalid
+  (module
+    (rec
+      (type $A (sub (struct))) ;; Not described by A.desc.
+    )
+    (rec
+      (type $A.desc (sub (struct))) ;; Does not describe A.
+    )
+    (rec
+      (type $B (sub $A (descriptor $B.desc) (struct)))
+      (type $B.desc (sub $A.desc (describes $B) (struct)))
+    )
+  )
+  "sub type 3 does not match super type 1"
+)
+
+;; The subtype of a descriptor must describe a subtype of the descriptor's
+;; described type.
+(assert_invalid
+  (module
+    (rec
+      (type $A (sub (descriptor $A.desc) (struct)))
+      (type $A.desc (sub (describes $A) (struct)))
+      (type $B (sub $A (struct))) ;; Not described by B.desc.
+      (type $B.desc (sub $A.desc (struct))) ;; Does not describe B.
+    )
+  )
+  "sub type 2 does not match super type 0"
+)
+(assert_invalid
+  (module
+    (rec
+      (type $A (sub (descriptor $A.desc) (struct)))
+      (type $A.desc (sub (describes $A) (struct)))
+    )
+    (rec
+      (type $B (sub $A (struct))) ;; Not described by B.desc.
+      (type $B.desc (sub $A.desc (struct))) ;; Does not describe B.
+    )
+  )
+  "sub type 2 does not match super type 0"
+)
+(assert_invalid
+  (module
+    (rec
+      (type $A (sub (descriptor $A.desc) (struct)))
+      (type $A.desc (sub (describes $A) (struct)))
+    )
+    (rec
+      (type $B (sub $A (struct))) ;; Not described by B.desc.
+    )
+    (rec
+      (type $B.desc (sub $A.desc (struct))) ;; Does not describe B.
+    )
+  )
+  "sub type 2 does not match super type 0"
 )


### PR DESCRIPTION
Check that descriptor and described types are properly paired, are
structs, and follow the subtyping rules.