### PR TITLE
Exact function imports

### DIFF
--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -320,7 +320,7 @@ let tabletype s =
 
 let externtype s =
   match byte s with
-  | 0x00 -> ExternFuncT (typeuse idx s)
+  | 0x00 -> ExternFuncT (heaptype s)
   | 0x01 -> ExternTableT (tabletype s)
   | 0x02 -> ExternMemoryT (memorytype s)
   | 0x03 -> ExternGlobalT (globaltype s)

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -207,7 +207,7 @@ struct
     | TableT (at, lim, t) -> reftype t; limits at lim
 
   let externtype = function
-    | ExternFuncT ut -> byte 0x00; typeuse u32 ut
+    | ExternFuncT ht -> byte 0x00; heaptype ht
     | ExternTableT tt -> byte 0x01; tabletype tt
     | ExternMemoryT mt -> byte 0x02; memorytype mt
     | ExternGlobalT gt -> byte 0x03; globaltype gt

--- a/interpreter/host/env.ml
+++ b/interpreter/host/env.ml
@@ -42,8 +42,8 @@ let exit vs =
 
 let lookup name et =
   match Utf8.encode name, et with
-  | "abort", ExternFuncT ut ->
+  | "abort", ExternFuncT (UseHT (_exact, ut)) ->
     ExternFunc (Func.alloc_host (deftype_of_typeuse ut) abort)
-  | "exit", ExternFuncT ut ->
+  | "exit", ExternFuncT (UseHT (_exact, ut)) ->
     ExternFunc (Func.alloc_host (deftype_of_typeuse ut) exit)
   | _ -> raise Not_found

--- a/interpreter/runtime/instance.ml
+++ b/interpreter/runtime/instance.ml
@@ -75,7 +75,7 @@ let externtype_of c = function
   | ExternGlobal glob -> ExternGlobalT (Global.type_of glob)
   | ExternMemory mem -> ExternMemoryT (Memory.type_of mem)
   | ExternTable tab -> ExternTableT (Table.type_of tab)
-  | ExternFunc func -> ExternFuncT (Def (Func.type_of func))
+  | ExternFunc func -> ExternFuncT (UseHT (Exact, Def (Func.type_of func)))
 
 let export inst name =
   try Some (List.assoc name inst.exports) with Not_found -> None

--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -422,7 +422,7 @@ let invoke dt vs at =
   let rts0 = Lib.List32.init subject_type_idx (fun i -> dummy, (dummy, i)) in
   let rts, i = statify_deftype rts0 dt in
   List.map (fun (_, (rt, _)) -> rt @@ at) (Lib.List32.drop subject_type_idx rts),
-  ExternFuncT (Idx i),
+  ExternFuncT (UseHT (Inexact, (Idx i))),
   List.concat (List.map value vs) @ [Call (subject_idx @@ at) @@ at]
 
 let get t at =
@@ -604,9 +604,9 @@ let wrap item_name wrap_action wrap_assertion at =
   let imports =
     [ Import (Utf8.decode "module", item_name, idesc) @@ at;
       Import (Utf8.decode "spectest", Utf8.decode "hostref",
-        ExternFuncT (Idx 1l)) @@ at;
+        ExternFuncT (UseHT (Inexact, (Idx 1l)))) @@ at;
       Import (Utf8.decode "spectest", Utf8.decode "eq_ref",
-        ExternFuncT (Idx 2l)) @@ at;
+        ExternFuncT (UseHT (Inexact, (Idx 2l)))) @@ at;
     ]
   in
   let item =
@@ -770,7 +770,7 @@ let of_action env act =
     "call(" ^ of_inst_opt env x_opt ^ ", " ^ of_name name ^ ", " ^
       "[" ^ String.concat ", " (List.map of_value vs) ^ "])",
     (match lookup_export env x_opt name act.at with
-    | ExternFuncT (Def dt) ->
+    | ExternFuncT (UseHT (_exact, (Def dt))) ->
       let (_, out) as ft = functype_of_comptype (expand_deftype dt) in
       if is_js_functype ft then
         None

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -413,7 +413,8 @@ let exporttype_of (m : module_) (ex : export) : exporttype =
       ExternTableT (Lib.List32.nth tts x.it)
     | FuncX x ->
       let dts = funcs xts @ List.map (fun f ->
-        let Func (y, _, _) = f.it in Def (Lib.List32.nth dts y.it)) m.it.funcs in
+        let Func (y, _, _) = f.it in
+        UseHT (Exact, Def (Lib.List32.nth dts y.it))) m.it.funcs in
       ExternFuncT (Lib.List32.nth dts x.it)
   in ExportT (name, subst_externtype (subst_of dts) xt)
 

--- a/interpreter/syntax/free.ml
+++ b/interpreter/syntax/free.ml
@@ -129,7 +129,7 @@ let externtype = function
   | ExternGlobalT gt -> globaltype gt
   | ExternMemoryT mt -> memorytype mt
   | ExternTableT tt -> tabletype tt
-  | ExternFuncT ut -> typeuse ut
+  | ExternFuncT ht -> heaptype ht
 
 let blocktype = function
   | VarBlockType x -> types (idx x)

--- a/interpreter/syntax/types.ml
+++ b/interpreter/syntax/types.ml
@@ -49,7 +49,7 @@ type externtype =
   | ExternGlobalT of globaltype
   | ExternMemoryT of memorytype
   | ExternTableT of tabletype
-  | ExternFuncT of typeuse
+  | ExternFuncT of heaptype
 
 type exporttype = ExportT of name * externtype
 type importtype = ImportT of name * name * externtype
@@ -124,6 +124,8 @@ let unpacked_fieldtype (FieldT (_mut, t)) = unpacked_storagetype t
 
 let idx_of_typeuse = function Idx x -> x | _ -> assert false
 let deftype_of_typeuse = function Def dt -> dt | _ -> assert false
+
+let typeuse_of_heaptype = function UseHT (_, ut) -> ut | _ -> assert false
 
 let structtype_of_comptype = function StructT fts -> fts | _ -> assert false
 let arraytype_of_comptype = function ArrayT ft -> ft | _ -> assert false
@@ -235,7 +237,7 @@ let subst_externtype s = function
   | ExternGlobalT gt -> ExternGlobalT (subst_globaltype s gt)
   | ExternMemoryT mt -> ExternMemoryT (subst_memorytype s mt)
   | ExternTableT tt -> ExternTableT (subst_tabletype s tt)
-  | ExternFuncT ut -> ExternFuncT (subst_typeuse s ut)
+  | ExternFuncT ht -> ExternFuncT (subst_heaptype s ht)
 
 
 let subst_exporttype s = function
@@ -446,7 +448,7 @@ let string_of_externtype = function
   | ExternGlobalT gt -> "global " ^ string_of_globaltype gt
   | ExternMemoryT mt -> "memory " ^ string_of_memorytype mt
   | ExternTableT tt -> "table " ^ string_of_tabletype tt
-  | ExternFuncT ut -> "func " ^ string_of_typeuse ut
+  | ExternFuncT ht -> "func " ^ string_of_heaptype ht
 
 
 let string_of_exporttype = function

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -84,6 +84,11 @@ let heaptype t = string_of_heaptype t
 let valtype t = string_of_valtype t
 let storagetype t = string_of_storagetype t
 
+let heaptypeuse = function
+  | UseHT (Inexact, ut) -> typeuse ut
+  | UseHT (Exact, ut) -> Node ("exact", [typeuse ut])
+  | _ -> assert false
+
 let final = function
   | NoFinal -> ""
   | Final -> " final"
@@ -708,7 +713,7 @@ let importtype fx tx mx tgx gx = function
   | ExternGlobalT gt -> incr gx; Node ("global $" ^ nat (!gx - 1), globaltype gt)
   | ExternMemoryT mt -> incr mx; Node ("memory $" ^ nat (!mx - 1), memorytype mt)
   | ExternTableT tt -> incr tx; Node ("table $" ^ nat (!tx - 1), tabletype tt)
-  | ExternFuncT ut -> incr fx; Node ("func $" ^ nat (!fx - 1), [typeuse ut])
+  | ExternFuncT ht -> incr fx; Node ("func $" ^ nat (!fx - 1), [heaptypeuse ht])
 
 let import fx tx mx ex gx im =
   let Import (module_name, item_name, xt) = im.it in

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -449,6 +449,10 @@ functype_result :
   | LPAR RESULT valtype_list RPAR functype_result
     { fun c -> snd $3 c @ $5 c }
 
+heapfunctype :
+  | LPAR EXACT functype RPAR { fun c -> Exact, $3 c }
+  | functype { fun c -> Inexact, $1 c }
+
 comptype :
   | LPAR STRUCT structtype RPAR { fun c x -> StructT ($3 c x) }
   | LPAR ARRAY arraytype RPAR { fun c x -> ArrayT ($3 c) }
@@ -488,6 +492,9 @@ limits :
 typeuse :
   | LPAR TYPE idx RPAR { fun c -> $3 c type_ }
 
+heaptypeuse :
+  | LPAR EXACT typeuse RPAR { fun c -> UseHT (Exact, Idx ($3 c).it) }
+  | typeuse { fun c -> UseHT (Inexact, Idx ($1 c).it) }
 
 /* Immediates */
 
@@ -991,16 +998,20 @@ func_fields :
       let y = inline_functype c' (fst $1 c') loc in
       let Func (_, ls, es) = snd $1 c' in
       [Func (y, ls, es) @@ loc], [], [] }
-  | inline_import typeuse func_fields_import  /* Sugar */
+  | inline_import heaptypeuse func_fields_import  /* Sugar */
     { fun c x loc ->
-      let y = inline_functype_explicit c ($2 c) ($3 c) in
+      let exact, y = match ($2 c) with
+        | UseHT (exact, Idx y) -> exact, y
+        | _ -> assert false
+      in
+      let y = inline_functype_explicit c (y @@ loc) ($3 c) in
       [],
-      [Import (fst $1, snd $1, ExternFuncT (Idx y.it)) @@ loc ], [] }
+      [Import (fst $1, snd $1, ExternFuncT (UseHT (exact, Idx y.it))) @@ loc ], [] }
   | inline_import func_fields_import  /* Sugar */
     { fun c x loc ->
       let y = inline_functype c ($2 c) loc in
       [],
-      [Import (fst $1, snd $1, ExternFuncT (Idx y.it)) @@ loc ], [] }
+      [Import (fst $1, snd $1, ExternFuncT (UseHT (Inexact, Idx y.it))) @@ loc ], [] }
   | inline_export func_fields  /* Sugar */
     { fun c x loc ->
       let fns, ims, exs = $2 c x loc in fns, ims, $1 (FuncX x) c :: exs }
@@ -1242,9 +1253,9 @@ table_fields :
 /* Imports & Exports */
 
 externtype :
-  | LPAR FUNC bindidx_opt typeuse RPAR
+  | LPAR FUNC bindidx_opt heaptypeuse RPAR
     { fun c -> ignore ($3 c anon_func bind_func);
-      fun () -> ExternFuncT (Idx ($4 c).it) }
+      fun () -> ExternFuncT ($4 c) }
   | LPAR TAG bindidx_opt typeuse RPAR
     { fun c -> ignore ($3 c anon_tag bind_tag);
       fun () -> ExternTagT (TagT (Idx ($4 c).it)) }
@@ -1260,9 +1271,12 @@ externtype :
   | LPAR TABLE bindidx_opt tabletype RPAR
     { fun c -> ignore ($3 c anon_table bind_table);
       fun () -> ExternTableT ($4 c) }
-  | LPAR FUNC bindidx_opt functype RPAR  /* Sugar */
+  | LPAR FUNC bindidx_opt heapfunctype RPAR  /* Sugar */
     { fun c -> ignore ($3 c anon_func bind_func);
-      fun () -> ExternFuncT (Idx (inline_functype c ($4 c) $loc($4)).it) }
+      fun () ->
+        let exact, ft = $4 c in
+        let y = inline_functype c ft $loc($4) in
+        ExternFuncT (UseHT (exact, Idx y.it)) }
 
 import :
   | LPAR IMPORT name name externtype RPAR

--- a/interpreter/valid/match.ml
+++ b/interpreter/valid/match.ml
@@ -184,5 +184,5 @@ let match_externtype c xt1 xt2 =
   | ExternGlobalT gt1, ExternGlobalT gt2 -> match_globaltype c gt1 gt2
   | ExternMemoryT mt1, ExternMemoryT mt2 -> match_memorytype c mt1 mt2
   | ExternTableT tt1, ExternTableT tt2 -> match_tabletype c tt1 tt2
-  | ExternFuncT (Def dt1), ExternFuncT (Def dt2) -> match_deftype c dt1 dt2
+  | ExternFuncT ht1, ExternFuncT ht2 -> match_heaptype c ht1 ht2
   | _, _ -> false

--- a/test/core/binary-leb128.wast
+++ b/test/core/binary-leb128.wast
@@ -667,7 +667,7 @@
   "\00"                                ;; import kind
   "\80\80\80\80\10"                    ;; import signature index 0 with unused bits set
 )
-  "integer too large"
+  "integer representation too long"
 )
 (assert_malformed
   (module binary

--- a/test/core/custom-descriptors/exact-func-import.wast
+++ b/test/core/custom-descriptors/exact-func-import.wast
@@ -1,0 +1,213 @@
+(module definition
+  (type $f (func))
+  (import "" "" (func $1 (exact (type 0))))
+  ;; (import "" "" (func $2 (exact (type $f) (param) (result)))) ;; TODO: parser support
+  (import "" "" (func $2 (exact (type $f))))
+  (import "" "" (func $3 (exact (type 1)))) ;; Implicitly defined next
+  (import "" "" (func $4 (exact (param i32) (result i64))))
+
+  (func $5 (import "" "") (exact (type 0)))
+  ;; (func $6 (import "" "") (exact (type $f) (param) (result))) ;; TODO: parser support
+  (func $6 (import "" "") (exact (type $f)))
+  ;; (func $7 (import "" "") (exact (type 2))) ;; Implicitly defined next
+  ;; (func $8 (import "" "") (exact (param i64) (result i32))) ;; TODO: parser support
+
+  (global (ref (exact $f)) (ref.func $1))
+  (global (ref (exact $f)) (ref.func $2))
+  (global (ref (exact 1)) (ref.func $3))
+  (global (ref (exact 1)) (ref.func $4))
+  (global (ref (exact $f)) (ref.func $5))
+  (global (ref (exact $f)) (ref.func $6))
+  ;; (global (ref (exact 2)) (ref.func $7))
+  ;; (global (ref (exact 2)) (ref.func $8))
+)
+
+;; References to inexact imports are not exact.
+
+(assert_invalid
+  (module
+    (type $f (func))
+    (import "" "" (func $1 (type $f)))
+    (global (ref (exact $f)) (ref.func $1))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (type $f (func))
+    (import "" "" (func $1 (type $f)))
+    (elem declare func $1)
+    (func (result (ref (exact $f)))
+      (ref.func $1)
+    )
+  )
+  "type mismatch"
+)
+
+;; Inexact imports can still be referenced inexactly, though.
+
+(module definition
+  (type $f (func))
+  (import "" "" (func $1 (type $f)))
+  (global (ref $f) (ref.func $1))
+  (func (result (ref $f))
+    (ref.func $1)
+  )
+)
+
+;; Define a function and export it exactly.
+(module $A
+  (type $f (func))
+  (func (export "f") (type $f))
+)
+(register "A")
+
+;; Import and re-export inexactly.
+(module $B
+  (type $f (func))
+  ;; (func (import "A" "f") (export "f") (type $f))
+  (func (import "A" "f") (type $f))
+  (export "f" (func 0))
+)
+(register "B")
+
+;; The export from A is exact.
+(module
+  (type $f (func))
+  (import "A" "f" (func (exact (type $f))))
+)
+
+;; The export from B is _statically_ inexact, but instantiation checks
+;; the dynamic types of imports, so this link still succeeds.
+(module
+  (type $f (func))
+  (import "B" "f" (func (exact (type $f))))
+)
+
+;; Even when the function is imported inexactly, it can still be cast to its
+;; exact type.
+(module
+  (type $f (func))
+  (import "A" "f" (func $1 (type $f)))
+  (elem declare func $1)
+  (func (export "exact-test") (result i32)
+    (ref.test (ref (exact $f)) (ref.func $1))
+  )
+  (func (export "exact-cast") (result (ref (exact $f)))
+    (ref.cast (ref (exact $f)) (ref.func $1))
+  )
+  (func (export "exact-br-on-cast") (result funcref)
+    (br_on_cast 0 funcref (ref (exact $f)) (ref.func $1))
+    (unreachable)
+  )
+  (func (export "exact-br-on-cast-fail") (result funcref)
+    (block (result funcref)
+      (br_on_cast_fail 0 funcref (ref (exact $f)) (ref.func $1))
+      (return)
+    )
+    (unreachable)
+  )
+)
+
+(assert_return (invoke "exact-test") (i32.const 1))
+(assert_return (invoke "exact-cast") (ref.func))
+(assert_return (invoke "exact-br-on-cast") (ref.func))
+(assert_return (invoke "exact-br-on-cast-fail") (ref.func))
+
+;; Define a function with a type that has a supertype.
+(module $C
+  (type $super (sub (func)))
+  (type $sub (sub $super (func)))
+  (func (export "f") (type $sub))
+  (func (export "g") (type $super))
+)
+(register "C")
+
+;; We should not be able to import the function with the exact supertype.
+(assert_unlinkable
+  (module
+    (type $super (sub (func)))
+    (type $sub (sub $super (func)))
+    (import "C" "f" (func (exact (type $super))))
+  )
+  "incompatible import type"
+)
+
+;; But we can still import it and re-export it inexactly with the supertype.
+(module $D
+  (type $super (sub (func)))
+  (type $sub (sub $super (func)))
+  (import "C" "f" (func (type $super)))
+  (export "f" (func 0))
+)
+(register "D")
+
+;; As before, we can still import the function with its real dynamic type.
+(module
+  (type $super (sub (func)))
+  (type $sub (sub $super (func)))
+  (import "D" "f" (func (exact (type $sub))))
+)
+
+;; As before, even when the function is imported inexactly (this time with its
+;; supertype), it can still be cast to its exact type.
+(module
+  (type $super (sub (func)))
+  (type $sub (sub $super (func)))
+  (import "C" "f" (func $1 (type $super)))
+  (elem declare func $1)
+  (func (export "exact-test") (result i32)
+    (ref.test (ref (exact $sub)) (ref.func $1))
+  )
+  (func (export "exact-cast") (result (ref (exact $sub)))
+    (ref.cast (ref (exact $sub)) (ref.func $1))
+  )
+  (func (export "exact-br-on-cast") (result funcref)
+    (br_on_cast 0 funcref (ref (exact $sub)) (ref.func $1))
+    (unreachable)
+  )
+  (func (export "exact-br-on-cast-fail") (result funcref)
+    (block (result funcref)
+      (br_on_cast_fail 0 funcref (ref (exact $sub)) (ref.func $1))
+      (return)
+    )
+    (unreachable)
+  )
+)
+
+(assert_return (invoke "exact-test") (i32.const 1))
+(assert_return (invoke "exact-cast") (ref.func))
+(assert_return (invoke "exact-br-on-cast") (ref.func))
+(assert_return (invoke "exact-br-on-cast-fail") (ref.func))
+
+;; But if we import a function whose dynamic type is the supertype, the same
+;; casts will fail.
+(module
+  (type $super (sub (func)))
+  (type $sub (sub $super (func)))
+  (import "C" "g" (func $1 (type $super)))
+  (elem declare func $1)
+  (func (export "exact-test") (result i32)
+    (ref.test (ref (exact $sub)) (ref.func $1))
+  )
+  (func (export "exact-cast") (result (ref (exact $sub)))
+    (ref.cast (ref (exact $sub)) (ref.func $1))
+  )
+  (func (export "exact-br-on-cast") (result funcref)
+    (br_on_cast 0 funcref (ref (exact $sub)) (ref.func $1))
+    (unreachable)
+  )
+  (func (export "exact-br-on-cast-fail") (result funcref)
+    (block (result funcref)
+      (br_on_cast_fail 0 funcref (ref (exact $sub)) (ref.func $1))
+      (return)
+    )
+    (unreachable)
+  )
+)
+
+(assert_return (invoke "exact-test") (i32.const 0))
+(assert_trap (invoke "exact-cast") "cast failure")
+(assert_trap (invoke "exact-br-on-cast") "unreachable")
+(assert_trap (invoke "exact-br-on-cast-fail") "unreachable")


### PR DESCRIPTION
Function references to imported functions must normally be inexact to
preserve soundness in the case where the dynamic type of the imported
function is a subtype of the import type. However, this difference
between imported and declared functions harms modularity by making it
possible for an instruction sequence to become invalid when a function
it references is replaced with an import.

To fix the modularity problem, introduce exact function imports that can
be referenced exactly, just as defined functions can.

Describe the problem and solution in the overview, and also update the
interpreter to make references to normal imported functions inexact and
to support exact function imports.

Fixes #57.
