### PR TITLE
[spec] Validation for exact heap types

### DIFF
--- a/document/core/valid/matching.rst
+++ b/document/core/valid/matching.rst
@@ -39,7 +39,8 @@ Heap Types
 $${rule-prose: Heaptype_sub}
 
 $${rule:
-  {Heaptype_sub/refl Heaptype_sub/trans}
+  {Heaptype_sub/refl Heaptype_sub/exact-l}
+  {Heaptype_sub/trans}
   {Heaptype_sub/eq-any Heaptype_sub/i31-eq Heaptype_sub/struct-eq Heaptype_sub/array-eq}
   {Heaptype_sub/struct Heaptype_sub/array Heaptype_sub/func}
   {Heaptype_sub/typeidx-l Heaptype_sub/typeidx-r}

--- a/document/core/valid/types.rst
+++ b/document/core/valid/types.rst
@@ -58,10 +58,6 @@ $${rule-prose: Heaptype_ok/abs}
 
 $${rule: Heaptype_ok/abs}
 
-$${rule-prose: Heaptype_ok/typeuse}
-
-$${rule: Heaptype_ok/typeuse}
-
 $${rule-prose: Heaptype_ok/exact}
 
 $${rule: Heaptype_ok/exact}

--- a/document/core/valid/types.rst
+++ b/document/core/valid/types.rst
@@ -58,6 +58,14 @@ $${rule-prose: Heaptype_ok/abs}
 
 $${rule: Heaptype_ok/abs}
 
+$${rule-prose: Heaptype_ok/typeuse}
+
+$${rule: Heaptype_ok/typeuse}
+
+$${rule-prose: Heaptype_ok/exact}
+
+$${rule: Heaptype_ok/exact}
+
 
 .. index:: reference type, heap type
    pair: validation; reference type

--- a/specification/wasm-latest/2.1-validation.types.spectec
+++ b/specification/wasm-latest/2.1-validation.types.spectec
@@ -24,6 +24,10 @@ rule Heaptype_ok/typeuse:
   C |- typeuse : OK
   -- Typeuse_ok: C |- typeuse : OK
 
+rule Heaptype_ok/exact:
+  C |- EXACT typeuse : OK
+  -- Typeuse_ok: C |- typeuse : OK
+
 rule Reftype_ok:
   C |- REF NULL? heaptype : OK
   -- Heaptype_ok: C |- heaptype : OK

--- a/specification/wasm-latest/2.2-validation.subtyping.spectec
+++ b/specification/wasm-latest/2.2-validation.subtyping.spectec
@@ -20,6 +20,10 @@ rule Vectype_sub:
 rule Heaptype_sub/refl:
   C |- heaptype <: heaptype
 
+rule Heaptype_sub/exact-l:
+  C |- EXACT typeuse <: heaptype
+  -- Heaptype_sub: C |- typeuse <: heaptype
+
 rule Heaptype_sub/trans:
   C |- heaptype_1 <: heaptype_2
   -- Heaptype_ok: C |- heaptype' : OK


### PR DESCRIPTION
Add Heaptype_ok/exact and Heaptype_sub/exact-l rules for exact heap
types in the spectec and in the doc.
