### PR TITLE
Disallow "L" subtyping

### DIFF
--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -184,10 +184,10 @@ let check_desctype_sub (c : context) (dt : desctype) (dt' : desctype) x x' at =
   | (Some ut2, Some ut2') ->
     require (match_typeuse c.types ut2 ut2') at ("descriptor type " ^
         string_of_typeuse ut2 ^ " does not match " ^ string_of_typeuse ut2')
-  | (None, Some _) ->
+  | (Some _, None) | (None, Some _) ->
     error at ("sub type " ^ I32.to_string_u x ^ " does not match super type " ^
         I32.to_string_u x')
-  | (Some _, None) | (None, None) -> ()
+  | (None, None) -> ()
   );
   require (match_comptype c.types ct ct') at ("sub type " ^ I32.to_string_u x ^
       " does not match super type " ^ I32.to_string_u x')

--- a/proposals/custom-descriptors/Overview.md
+++ b/proposals/custom-descriptors/Overview.md
@@ -128,8 +128,8 @@ Just like any other struct types,
 struct types with `describes` or `descriptor` clauses support width and depth subtyping.
 However, the following new subtyping rules are introduced:
 
- - A declared supertype of a type with a `(descriptor $x)` clause must either
-   not have a `descriptor` clause or have a `(descriptor $y)` clause,
+ - A declared supertype of a type with a `(descriptor $x)` clause
+   must have a `(descriptor $y)` clause,
    where `$y` is a declared supertype of `$x`.
 
  - A declared supertype of a type without a `descriptor` clause must also
@@ -148,16 +148,34 @@ However, the following new subtyping rules are introduced:
    > Note: this could be relaxed to allow unshared described types to have shared descriptor types
    > (but not vice versa) if there is demand for this in the future.
 
+These rules combined form the "complete square" rule:
+
+```
+A -> A.desc
+^    ^
+B -> B.desc
+```
+
+The vertical arrows denote supertypes and horizontal arrows denote descriptors.
+If any single type or edge is missing from this diagram,
+then the types are invalid.
+
 The first two rules,
 governing types with or without `descriptor` clauses,
 are necessary to ensure the soundness of the `ref.get_desc` instruction described below.
 The latter two rules,
 governing types with or without `describes` clauses,
-are necessary to ensure subtypes have layouts compatible with their supertypes.
+are necessary to ensure the soundness of the `ref.cast_desc_eq` family of instructions.
+
+In general, descriptor types can only be subtypes of other descriptor types
+(and non-descriptor types can only be subtypes of other non-descriptor types)
+to ensure subtypes and their supertypes have compatible layouts.
 Custom descriptor types (i.e. those with `describes` clauses)
 may have different layouts than other structs because their user-controlled fields
 might be laid out after the engine-managed RTT for the type they describe.
 (But this is just one possible implementation that we specifically want to allow.)
+Similarly, described types may have different layouts than non-described types
+if the engine has to add an internal field to refer to their descriptors.
 
 ```wasm
 (rec
@@ -172,7 +190,7 @@ might be laid out after the engine-managed RTT for the type they describe.
 (rec
   (type $super (sub (struct)))
 
-  ;; Ok
+  ;; Invalid: $super must have a descriptor that is a supertype of $sub.desc.
   (type $sub (sub $super (descriptor $sub.desc) (struct)))
   (type $sub.desc (describes $sub) (struct))
 )

--- a/test/core/custom-descriptors/br_on_cast_desc_eq.wast
+++ b/test/core/custom-descriptors/br_on_cast_desc_eq.wast
@@ -458,8 +458,14 @@
     (type $a (sub (descriptor $b) (struct)))
     (type $b (sub (describes $a) (struct)))
     (type $c (sub $a (descriptor $d) (struct)))
-    (type $d (sub $b (describes $c) (descriptor $e) (struct)))
-    (type $e (describes $d) (struct))
+    (type $d (sub $b (describes $c) (struct)))
+    (type $e (struct))
+  )
+
+  (rec
+    (type $s (sub (descriptor $s') (struct)))
+    (type $s' (sub (describes $s) (descriptor $s'') (struct)))
+    (type $s'' (sub (describes $s') (struct)))
   )
 
   ;; Cast to self
@@ -661,18 +667,18 @@
   )
 
   ;; Cast to descriptor type
-  (func (param (ref null any) (ref null $e)) (result (ref null $d))
+  (func (param (ref null any) (ref null $s'')) (result (ref null $s'))
     (block (result (ref any))
-      (br_on_cast_desc_eq 1 (ref null any) (ref null $d)
+      (br_on_cast_desc_eq 1 (ref null any) (ref null $s')
         (local.get 0)
         (local.get 1)
       )
     )
     (unreachable)
   )
-  (func (param (ref null any) (ref null (exact $e))) (result (ref null (exact $d)))
+  (func (param (ref null any) (ref null (exact $s''))) (result (ref null (exact $s')))
     (block (result (ref any))
-      (br_on_cast_desc_eq 1 (ref null any) (ref null (exact $d))
+      (br_on_cast_desc_eq 1 (ref null any) (ref null (exact $s'))
         (local.get 0)
         (local.get 1)
       )

--- a/test/core/custom-descriptors/br_on_cast_desc_eq_fail.wast
+++ b/test/core/custom-descriptors/br_on_cast_desc_eq_fail.wast
@@ -434,8 +434,14 @@
     (type $a (sub (descriptor $b) (struct)))
     (type $b (sub (describes $a) (struct)))
     (type $c (sub $a (descriptor $d) (struct)))
-    (type $d (sub $b (describes $c) (descriptor $e) (struct)))
-    (type $e (describes $d) (struct))
+    (type $d (sub $b (describes $c) (struct)))
+    (type $e (struct))
+  )
+
+  (rec
+    (type $s (sub (descriptor $s') (struct)))
+    (type $s' (sub (describes $s) (descriptor $s'') (struct)))
+    (type $s'' (sub (describes $s') (struct)))
   )
 
   ;; Cast to self
@@ -639,18 +645,18 @@
   )
 
   ;; Cast to descriptor type
-  (func (param (ref null any) (ref null $e)) (result (ref any))
-    (block (result (ref null $d))
-      (br_on_cast_desc_eq_fail 1 (ref null any) (ref null $d)
+  (func (param (ref null any) (ref null $s'')) (result (ref any))
+    (block (result (ref null $s'))
+      (br_on_cast_desc_eq_fail 1 (ref null any) (ref null $s')
         (local.get 0)
         (local.get 1)
       )
     )
     (unreachable)
   )
-  (func (param (ref null any) (ref null (exact $e))) (result (ref any))
-    (block (result (ref null (exact $d)))
-      (br_on_cast_desc_eq_fail 1 (ref null any) (ref null (exact $d))
+  (func (param (ref null any) (ref null (exact $s''))) (result (ref any))
+    (block (result (ref null (exact $s')))
+      (br_on_cast_desc_eq_fail 1 (ref null any) (ref null (exact $s'))
         (local.get 0)
         (local.get 1)
       )

--- a/test/core/custom-descriptors/descriptors.wast
+++ b/test/core/custom-descriptors/descriptors.wast
@@ -262,23 +262,29 @@
   )
 )
 
-;; If a subtype has a descriptor, its supertype does not need to have a
-;; descriptor.
-(module
-  (rec
-    (type $A (sub (struct)))
-    (type $B (sub $A (descriptor $B.desc) (struct)))
-    (type $B.desc (sub (describes $B) (struct)))
+;; If a subtype has a descriptor, its supertype have a descriptor that is the
+;; supertype of the subtype's descriptor
+(assert_invalid
+  (module
+    (rec
+      (type $A (sub (struct)))
+      (type $B (sub $A (descriptor $B.desc) (struct)))
+      (type $B.desc (sub (describes $B) (struct)))
+    )
   )
+  "sub type 1 does not match super type 0"
 )
-(module
-  (rec
-    (type $A (sub (struct)))
+(assert_invalid
+  (module
+    (rec
+      (type $A (sub (struct)))
+    )
+    (rec
+      (type $B (sub $A (descriptor $B.desc) (struct)))
+      (type $B.desc (sub (describes $B) (struct)))
+    )
   )
-  (rec
-    (type $B (sub $A (descriptor $B.desc) (struct)))
-    (type $B.desc (sub (describes $B) (struct)))
-  )
+  "sub type 1 does not match super type 0"
 )
 
 ;; If a supertype has a descriptor, its subtype must also have a descriptor.
@@ -421,7 +427,7 @@
       (type $B.desc (sub $A.desc (describes $B) (struct)))
     )
   )
-  "sub type 3 does not match super type 1"
+  "sub type 2 does not match super type 0"
 )
 (assert_invalid
   (module
@@ -434,7 +440,7 @@
       (type $B.desc (sub $A.desc (describes $B) (struct)))
     )
   )
-  "sub type 3 does not match super type 1"
+  "sub type 2 does not match super type 0"
 )
 (assert_invalid
   (module
@@ -449,7 +455,7 @@
       (type $B.desc (sub $A.desc (describes $B) (struct)))
     )
   )
-  "sub type 3 does not match super type 1"
+  "sub type 2 does not match super type 0"
 )
 
 ;; The subtype of a descriptor must describe a subtype of the descriptor's

--- a/test/core/custom-descriptors/ref_cast_desc_eq.wast
+++ b/test/core/custom-descriptors/ref_cast_desc_eq.wast
@@ -170,8 +170,14 @@
     (type $a (sub (descriptor $b) (struct)))
     (type $b (sub (describes $a) (struct)))
     (type $c (sub $a (descriptor $d) (struct)))
-    (type $d (sub $b (describes $c) (descriptor $e) (struct)))
-    (type $e (describes $d) (struct))
+    (type $d (sub $b (describes $c) (struct)))
+    (type $e (struct))
+  )
+
+  (rec
+    (type $s (sub (descriptor $s') (struct)))
+    (type $s' (sub (describes $s) (descriptor $s'') (struct)))
+    (type $s'' (sub (describes $s') (struct)))
   )
 
   ;; Cast to self
@@ -255,11 +261,11 @@
   )
 
   ;; Cast to descriptor type
-  (func (param (ref null any) (ref null $e)) (result (ref null $d))
-    (ref.cast_desc_eq (ref null $d) (local.get 0) (local.get 1))
+  (func (param (ref null any) (ref null $s'')) (result (ref null $s'))
+    (ref.cast_desc_eq (ref null $s') (local.get 0) (local.get 1))
   )
-  (func (param (ref null any) (ref null (exact $e))) (result (ref null (exact $d)))
-    (ref.cast_desc_eq (ref null (exact $d)) (local.get 0) (local.get 1))
+  (func (param (ref null any) (ref null (exact $s''))) (result (ref null (exact $s')))
+    (ref.cast_desc_eq (ref null (exact $s')) (local.get 0) (local.get 1))
   )
 )
 


### PR DESCRIPTION
Update the overview, interpreter, and tests to reflect the decision that the "L" subtyping pattern, in which a subtype has a descriptor but its supertype does not, should be disallowed.

The spectec is not updated because it does not yet include the relevant subtyping rules.

Closes #109.
